### PR TITLE
Add missing workshop ids in config.ini

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -39,6 +39,18 @@ MAP[] = "de_train"
 MAP[] = "de_mirage"
 
 [WORKSHOP IDs]
+WORKSHOP["de_dust2_se"] = "125488374"
+WORKSHOP["de_nuke_se"] = "125498553"
+WORKSHOP["de_inferno_se"] = "125499116"
+WORKSHOP["de_mirage_ce"] = "123769103"
+WORKSHOP["de_train_se"] = "125498231"
+WORKSHOP["de_cache"] = "163589843"
+WORKSHOP["de_season"] = "125689191"
+WORKSHOP["de_dust2"] = "125438255"
+WORKSHOP["de_nuke"] = "125439125"
+WORKSHOP["de_inferno"] = "125438669"
+WORKSHOP["de_mirage"] = "152508932"
+WORKSHOP["de_train"] = "125438372"
 
 [Settings]
 COMMAND_STOP_DISABLED = false


### PR DESCRIPTION
Les IDs des maps provenant du workshop sont manquantes sur la branche pthreads. Ceci bloque le script bootstrap.php