### PR TITLE
Allow to set up eBot behind NAT. #103

### DIFF
--- a/config/config.ini.smp
+++ b/config/config.ini.smp
@@ -12,7 +12,9 @@ MYSQL_PASS = "ebotv3"
 MYSQL_BASE = "ebotv3"
 
 [Config]
-BOT_IP = "127.0.0.1"
+; EXTERNAL_IP = "" ; External IP address. Uncomment if you are behind NAT or using virtualization like lxc/docker.
+; URL_ROOT="http://ebot.example.com" ; without trailing slash. Used for demo upload. Uncomment if CS:GO is on different server.
+BOT_IP = "127.0.0.1" ; IP of interface to listen on. Make sure it is not 127.0.0.1 if CS:GO server is on different server.
 BOT_PORT = 12360
 MANAGE_PLAYER = 1
 DELAY_BUSY_SERVER = 120

--- a/src/eBot/Config/Config.php
+++ b/src/eBot/Config/Config.php
@@ -24,6 +24,8 @@ class Config extends Singleton {
     private $mysql_pass;
     private $mysql_base;
     private $bot_ip;
+    private $external_ip;
+    private $url_root;
     private $bot_port;
     private $messages = array();
     private $record_name = "ebot";
@@ -54,7 +56,18 @@ class Config extends Singleton {
             $this->mysql_base = $config["MYSQL_BASE"];
 
             $this->bot_ip = $config["BOT_IP"];
+            $this->external_ip = $config["EXTERNAL_IP"];
+            
+            if($this->external_ip == ""){
+                $this->external_ip = $this->bot_ip;
+            }
+            
+            $this->url_root = $config["URL_ROOT"];
             $this->bot_port = $config["BOT_PORT"];
+
+            if($this->url_root == ""){
+                $this->url_root = 'http://'.$this->bot_ip.':'.$this->bot_port;
+            }
 
             $this->delay_busy_server = $config["DELAY_BUSY_SERVER"];
 
@@ -172,6 +185,20 @@ class Config extends Singleton {
 
     public function setBot_ip($bot_ip) {
         $this->bot_ip = $bot_ip;
+    }
+    public function getExternal_ip() {
+        return $this->external_ip;
+    }
+
+    public function setExternal_ip($external_ip) {
+        $this->external_ip = $external_ip;
+    }
+    public function getUrl_root() {
+        return $this->url_root;
+    }
+
+    public function setUrl_root($url_root) {
+        $this->url_root = $url_root;
     }
 
     public function getBot_port() {

--- a/src/eBot/Match/Match.php
+++ b/src/eBot/Match/Match.php
@@ -166,7 +166,7 @@ class Match implements Taskable {
             $this->rcon = new Rcon($ip[0], $ip[1], $rcon);
             $this->rconPassword = $rcon;
             Logger::log("RCON init ok");
-            $this->rcon->send("log on; mp_logdetail 3; logaddress_del " . \eBot\Config\Config::getInstance()->getBot_ip() . ":" . \eBot\Config\Config::getInstance()->getBot_port() . ";logaddress_add " . \eBot\Config\Config::getInstance()->getBot_ip() . ":" . \eBot\Config\Config::getInstance()->getBot_port());
+            $this->rcon->send("log on; mp_logdetail 3; logaddress_del " . \eBot\Config\Config::getInstance()->getExternal_ip() . ":" . \eBot\Config\Config::getInstance()->getBot_port() . ";logaddress_add " . \eBot\Config\Config::getInstance()->getExternal_ip() . ":" . \eBot\Config\Config::getInstance()->getBot_port());
             $this->rcon->send("sv_rcon_whitelist_address \"" . \eBot\Config\Config::getInstance()->getBot_ip() . "\"");
             $this->addMatchLog("- RCON connection OK", true, false);
         } catch (\Exception $ex) {
@@ -593,7 +593,7 @@ class Match implements Taskable {
             $this->addLog("Stopping record and pushing demo...");
 //            $this->rcon->send("tv_stoprecord");
             if (\eBot\Config\Config::getInstance()->getDemoDownload()) {
-                $this->rcon->send('tv_stoprecord; ' . 'csay_tv_demo_push "' . $this->currentRecordName . '.dem" "http://' . \eBot\Config\Config::getInstance()->getBot_ip() . ':' . \eBot\Config\Config::getInstance()->getBot_port() . '/upload"');
+                $this->rcon->send('tv_stoprecord; ' . 'csay_tv_demo_push "' . $this->currentRecordName . '.dem" "' . \eBot\Config\Config::getInstance()->getUrl_root() . '/upload"');
             } else {
                 $this->rcon->send("tv_stoprecord");
             }


### PR DESCRIPTION
Fixes #103 by introducing new configuration variables.
I'm now using eBot behind NAT in lxc container.