### PR TITLE
Remove composer.lock file from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 vendor
 composer.phar
-composer.lock
 config/config.ini
 demos/*.dem*
 logs/*

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,67 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "15db50e87a8a3769f4464c85c5d28a15",
+    "content-hash": "07682957686a5954cfd07cd80f7f3f75",
+    "packages": [
+        {
+            "name": "koraktor/steam-condenser",
+            "version": "1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/koraktor/steam-condenser-php.git",
+                "reference": "15b25c0f32eb6f47811fe7f35606493e2c3603c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/koraktor/steam-condenser-php/zipball/15b25c0f32eb6f47811fe7f35606493e2c3603c7",
+                "reference": "15b25c0f32eb6f47811fe7f35606493e2c3603c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "lib/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Staudt",
+                    "email": "koraktor@gmail.com"
+                }
+            ],
+            "description": "The Steam Condenser is a multi-language library for querying the Steam Community, Source and GoldSrc game servers",
+            "homepage": "http://koraktor.de/steam-condenser",
+            "keywords": [
+                "community",
+                "goldsrc",
+                "query",
+                "source",
+                "steam",
+                "webapi"
+            ],
+            "time": "2013-07-16 21:07:43"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}


### PR DESCRIPTION
Hi!

`composer.lock` file needs to be in version control.

> This is important because the install command checks if a lock file is present, and if it is, it downloads the versions specified there (regardless of what composer.json says).

[Reference](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file)
