### PR TITLE
Added http log receiver on endpoint BOT_IP:BOT_PORT/csgologs

### DIFF
--- a/src/eBot/Application/Application.php
+++ b/src/eBot/Application/Application.php
@@ -94,6 +94,16 @@ class Application extends AbstractApplication {
                 $d = explode("---", $loggerData->shift());
                 $ip = array_shift($d);
                 $data = implode("---", $d);
+
+                $type="D";
+
+                if(strpos($data,'*') !== false){
+                    $type="C";
+                    $data=explode("*",$data,2);
+                    $ip=$data[0];
+                    $data="L ".$data[1];
+                }
+
                 $nbMessage--;
             } else {
                 usleep(500);
@@ -265,6 +275,7 @@ class Application extends AbstractApplication {
 
                     if (\eBot\Manager\MatchManager::getInstance()->getMatch($ip)) {
                         file_put_contents(APP_ROOT . "/logs/$ip", $line, FILE_APPEND);
+
                         $line = trim(substr($line, 23));
                         \eBot\Manager\MatchManager::getInstance()->getMatch($ip)->processMessage($line);
                         $line = substr($data, 7, strlen($data) - 8);

--- a/src/eBot/Match/Match.php
+++ b/src/eBot/Match/Match.php
@@ -167,7 +167,7 @@ class Match implements Taskable {
             $this->rcon = new Rcon($ip[0], $ip[1], $rcon);
             $this->rconPassword = $rcon;
             Logger::log("RCON init ok");
-            $this->rcon->send("log on; mp_logdetail 3; logaddress_del " . \eBot\Config\Config::getInstance()->getLogAddressIp() . ":" . \eBot\Config\Config::getInstance()->getBot_port() . ";logaddress_add " . \eBot\Config\Config::getInstance()->getLogAddressIp() . ":" . \eBot\Config\Config::getInstance()->getBot_port());
+            $this->rcon->send("log on; mp_logdetail 3; logaddress_del " . \eBot\Config\Config::getInstance()->getLogAddressIp() . ":" . \eBot\Config\Config::getInstance()->getBot_port() . "; logaddress_add_http \"http://" . \eBot\Config\Config::getInstance()->getLogAddressIp() . ":" . \eBot\Config\Config::getInstance()->getBot_port()."/csgologs\"");
             $this->rcon->send("sv_rcon_whitelist_address \"" . \eBot\Config\Config::getInstance()->getLogAddressIp() . "\"");
             $this->addMatchLog("- RCON connection OK", true, false);
         } catch (\Exception $ex) {


### PR DESCRIPTION
Without re-writting the entire application, added a http log receiver which then relays the information via UDP to the bot. 
Since the logs are received from the gameserver via HTTP and then sent from the same machine via UDP, it will reduce packet loss (http has packet confirmation), and therefor reduce the number of events missed by ebot, preventing a few bugs such as a the "round jump" one.