### PR TITLE
Fix loading workshop maps in cs2

### DIFF
--- a/src/eBot/Match/Match.php
+++ b/src/eBot/Match/Match.php
@@ -702,10 +702,14 @@ class Match implements Taskable
 
             // Changing map
             $this->addLog("Changing map to: '" . $this->currentMap->getMapName() . "'.");
-            if (\eBot\Config\Config::getInstance()->getWorkshop() && \eBot\Config\Config::getInstance()->getWorkshopByMap($this->currentMap->getMapName()))
-                $this->rcon->send("changelevel workshop/" . \eBot\Config\Config::getInstance()->getWorkshopByMap($this->currentMap->getMapName()) . "/" . $this->currentMap->getMapName());
-            else
+            if (\eBot\Config\Config::getInstance()->getWorkshop() && \eBot\Config\Config::getInstance()->getWorkshopByMap($this->currentMap->getMapName())) {
+                $this->addLog("Detected a workshop map, loading it using host_workshop_map.");
+                $this->rcon->send("host_workshop_map " . \eBot\Config\Config::getInstance()
+                    ->getWorkshopByMap($this->currentMap->getMapName()) . "/" . $this->currentMap->getMapName());
+            }
+            else {
                 $this->rcon->send("changelevel " . $this->currentMap->getMapName());
+            }
 
             if ($this->config_kniferound) {
                 $this->setStatus(self::STATUS_WU_KNIFE, true);

--- a/src/eBot/Match/Match.php
+++ b/src/eBot/Match/Match.php
@@ -705,7 +705,7 @@ class Match implements Taskable
             if (\eBot\Config\Config::getInstance()->getWorkshop() && \eBot\Config\Config::getInstance()->getWorkshopByMap($this->currentMap->getMapName())) {
                 $this->addLog("Detected a workshop map, loading it using host_workshop_map.");
                 $this->rcon->send("host_workshop_map " . \eBot\Config\Config::getInstance()
-                    ->getWorkshopByMap($this->currentMap->getMapName()) . "/" . $this->currentMap->getMapName());
+                    ->getWorkshopByMap($this->currentMap->getMapName()));
             }
             else {
                 $this->rcon->send("changelevel " . $this->currentMap->getMapName());


### PR DESCRIPTION
Loading workshop maps has been changed in CS2. In CS:Go you could load the map to your server and use `map workshop/1234/mapname` to load the map.

In CS2 you don't need to load the mapfiles to the server anymore and the command has been changed to host_workshop_map.

I changed the part where workshop maps get loaded in the PR. Please take a look :)